### PR TITLE
Remove global git-blame-ignore-files.

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -28,8 +28,6 @@
 	conflictstyle = zdiff3
 [init]
 	defaultBranch = main
-[blame]
-	ignoreRevsFile = .git-blame-ignore-revs
 [column]
 	ui = auto
 [tag]


### PR DESCRIPTION
Unfortunately when a global blame ignore file X is configured and a repo doesn't not have X then git blame throws an error. I think I am better off just setting local blame ignore files going forward.