### PR TITLE
Claude workflow, permissions, and nvim updates

### DIFF
--- a/ai_workflow.sh
+++ b/ai_workflow.sh
@@ -55,10 +55,12 @@ start-task() {
   command tmux split-window -t ":${branch}.0" -h -p 40 -c "$worktree_path"
   # Split the right column in half vertically to make the bottom terminal pane (pane 2)
   command tmux split-window -t ":${branch}.1" -v -p 50 -c "$worktree_path"
+  # Wait for shells to initialize (oh-my-zsh, etc.) before sending keystrokes
+  sleep 2
   # Type "vim ." into the left pane and press Enter
   command tmux send-keys -t ":${branch}.0" "vim ." Enter
   # Type the claude command into the top-right pane; printf '%q' safely escapes the task string
-  command tmux send-keys -t ":${branch}.1" "claude $(printf '%q' "$task")" Enter
+  command tmux send-keys -t ":${branch}.1" "claude --permission-mode dontAsk $(printf '%q' "$task")" Enter
   # Move focus to the claude pane
   command tmux select-pane -t ":${branch}.1"
   echo "Spawned '$branch' → $worktree_path"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,6 +3,9 @@
     "commit": "",
     "pr": ""
   },
+  "enabledMcpjsonServers": [
+    "next-devtools"
+  ],
   "permissions": {
     "allow": [
       "Read(**)",
@@ -22,6 +25,20 @@
       "Bash(echo:*)",
       "Bash(source:*)",
       "Bash(which:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(cat:*)",
+      "Bash(wc:*)",
+      "Bash(sort:*)",
+      "Bash(uniq:*)",
+      "Bash(cut:*)",
+      "Bash(tr:*)",
+      "Bash(diff:*)",
+      "Bash(pwd:*)",
+      "Bash(date:*)",
+      "Bash(basename:*)",
+      "Bash(dirname:*)",
+      "Bash(file:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git diff:*)",
@@ -117,5 +134,6 @@
     "enabled": true,
     "mode": "hold"
   },
+  "editorMode": "vim",
   "voiceEnabled": true
 }

--- a/nvim/lua/danny/plugins/markdown-preview.lua
+++ b/nvim/lua/danny/plugins/markdown-preview.lua
@@ -3,4 +3,7 @@ return {
   cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
   ft = { "markdown" },
   build = "cd app && npm install",
+  init = function()
+    vim.g.mkdp_auto_close = 0
+  end,
 }


### PR DESCRIPTION
## Description
Quality-of-life improvements to the Claude Code workflow tooling, permission config,
and neovim plugin setup.

## Change Summary
- **ai_workflow.sh**: Add 2s shell init delay before `send-keys` to avoid oh-my-zsh race
  condition; launch Claude with `--permission-mode dontAsk` for prompt-free worktree sessions
- **claude/settings.json**: Expand bash allow list with safe read-only commands (`head`, `tail`,
  `cat`, `wc`, `sort`, `uniq`, `cut`, `tr`, `diff`, `pwd`, `date`, `basename`, `dirname`,
  `file`); pre-approve `next-devtools` MCP server globally via `enabledMcpjsonServers`
- **nvim/lua/danny/plugins/markdown-preview.lua**: Disable `mkdp_auto_close` so the browser
  preview stays open when switching buffers