### PR TITLE
Dotfiles updates: Claude commands, ai_workflow, nvim plugins

### DIFF
--- a/ai_workflow.sh
+++ b/ai_workflow.sh
@@ -60,7 +60,7 @@ start-task() {
   # Type "vim ." into the left pane and press Enter
   command tmux send-keys -t ":${branch}.0" "vim ." Enter
   # Build the claude command — include the task only if one was provided
-  local claude_cmd="claude --permission-mode dontAsk"
+  local claude_cmd="claude --permission-mode plan"
   [[ -n "$task" ]] && claude_cmd+=" $(printf '%q' "$task")"
   # Type the claude command into the top-right pane
   command tmux send-keys -t ":${branch}.1" "$claude_cmd" Enter
@@ -79,8 +79,8 @@ list-tasks() {
 
 # kill-task <branch> — remove worktree + close tmux window
 kill-task() {
-  local branch="$1"
-  # Bail if no branch name given
+  local branch="${1:-$(git branch --show-current 2>/dev/null)}"
+  # Bail if no branch name given or couldn't detect current branch
   if [[ -z "$branch" ]]; then
     echo "Usage: kill-task <branch-name>"
     return 1

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -3,13 +3,51 @@
 Start: say hi + 1 motivating line.
 Work style: loose grammar; minimize tokens; educational but casual tone;
 
+## Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+- After implementation is complete, run /simplify
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
 ## Agent Protocol
 - “Make a note” => edit CLAUDE.md
 - Bugs: add regression test when it fits.
 - Keep files <~500 LOC; split/refactor as needed.
 - New deps: quick health check (recent releases/commits, adoption).
 - Web: search early; quote exact errors; prefer sources from within the last 2 years
-- Don't delete existing comments unless explictly asked to or when editing the code the comment pertains to.
 - Plan .md files: always write to `.claude/plans/` in the active project, never to `~/.claude/`.
 - Markdown files: wrap prose lines at 100 characters; leave code blocks unwrapped.
 

--- a/claude/commands/iterate.md
+++ b/claude/commands/iterate.md
@@ -1,0 +1,11 @@
+Review feedback on the current PR, incorporate it, then ship the changes.
+
+Steps:
+1. Run `gh pr view --comments` and `gh pr view --json reviews` to collect all review comments and inline feedback.
+2. Read the current diff (`git diff main...HEAD`) to understand what's already changed.
+3. For each piece of feedback, make the necessary code changes. Group related changes into logical commits.
+4. Once all feedback is addressed, use /ship to commit, push, and update the PR.
+
+Notes:
+- If feedback is ambiguous or contradictory, flag it and ask before changing code.
+- Do not close or merge the PR.

--- a/claude/commands/ship.md
+++ b/claude/commands/ship.md
@@ -1,0 +1,18 @@
+Commit all changes, push to remote, and create or update the PR description.
+
+Steps:
+1. Run `git status` and `git diff` to review what's changed.
+2. Stage and commit any unstaged changes using a concise imperative commit message (≤72 chars).
+   - Skip if there's nothing to commit.
+3. Push the current branch to remote (with `-u` if no upstream is set yet).
+4. Check if a PR already exists for this branch (`gh pr view`).
+   - If yes: update its title and body with `gh pr edit` to reflect the current diff vs main.
+   - If no: create one with `gh pr create` using the standard title + body format.
+5. Output the PR URL.
+
+PR body format:
+## Description
+[what changed and why]
+
+## Change Summary
+[bullet list of affected files/components and their changes]

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -21,6 +21,7 @@
   "nvim-tree.lua": { "branch": "master", "commit": "321bc61580fd066b76861c32de3319c3a6d089e7" },
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-treesitter-context": { "branch": "master", "commit": "660861b1849256398f70450afdf93908d28dc945" },
+  "nvim-ts-context-commentstring": { "branch": "main", "commit": "6141a40173c6efa98242dc951ed4b6f892c97027" },
   "nvim-web-devicons": { "branch": "master", "commit": "8dcb311b0c92d460fac00eac706abd43d94d68af" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "telescope.nvim": { "branch": "master", "commit": "6312868392331c9c0f22725041f1ec2bef57c751" },

--- a/nvim/lua/danny/plugins/comment.lua
+++ b/nvim/lua/danny/plugins/comment.lua
@@ -1,7 +1,10 @@
 return {
   'numToStr/Comment.nvim',
+  dependencies = { 'JoosepAlviste/nvim-ts-context-commentstring' },
   config = function()
-    require('Comment').setup()
+    require('Comment').setup({
+      pre_hook = require('ts_context_commentstring.integrations.comment_nvim').create_pre_hook(),
+    })
 
     -- Ctrl+_ for commenting
     local api = require('Comment.api')

--- a/nvim/lua/danny/plugins/treesitter.lua
+++ b/nvim/lua/danny/plugins/treesitter.lua
@@ -6,7 +6,7 @@ return {
 
     configs.setup({
       ensure_installed = {
-        "lua", "vim", "vimdoc", "javascript", "typescript", "html", "css", "python", "json", "yaml", "markdown", "bash", "c_sharp"
+        "lua", "vim", "vimdoc", "javascript", "typescript", "tsx", "html", "css", "python", "json", "yaml", "markdown", "bash", "c_sharp"
       },
       sync_install = false,
       highlight = { enable = true },

--- a/nvim/lua/danny/plugins/ts-context-commentstring.lua
+++ b/nvim/lua/danny/plugins/ts-context-commentstring.lua
@@ -1,0 +1,8 @@
+return {
+  'JoosepAlviste/nvim-ts-context-commentstring',
+  lazy = true,
+  opts = {
+    -- Disable the autocommand-based behavior; Comment.nvim drives it via pre_hook
+    enable_autocmd = false,
+  },
+}


### PR DESCRIPTION
## Description
A collection of improvements to the dotfiles setup: new Claude Code slash commands for shipping and PR
iteration, quality-of-life fixes to the AI workflow shell functions, expanded CLAUDE.md guidelines, and
a new Neovim plugin for context-aware commenting.

## Change Summary
- **`claude/commands/ship.md`** — new `/ship` command: commit, push, and create/update PR description
- **`claude/commands/iterate.md`** — new `/iterate` command: pull PR review feedback, apply it, then
  `/ship`
- **`claude/CLAUDE.md`** — added "Think Before Coding", "Simplicity First", and "Surgical Changes"
  sections to sharpen Claude's default behavior
- **`ai_workflow.sh`** — `start-task` now launches Claude in `plan` permission mode (was `dontAsk`);
  `kill-task` defaults to the current branch when no argument is passed
- **`nvim/lua/danny/plugins/ts-context-commentstring.lua`** — new plugin for Treesitter-aware comment
  strings in embedded languages (JSX, Vue, etc.)
- **`nvim/lua/danny/plugins/comment.lua`** — wired `nvim-ts-context-commentstring` via `pre_hook`
- **`nvim/lua/danny/plugins/treesitter.lua`** — added `tsx` to `ensure_installed`
- **`nvim/lazy-lock.json`** — locked `nvim-ts-context-commentstring` at install commit